### PR TITLE
A proposal to make notes and warnings more visible.

### DIFF
--- a/sphinx/static/bottle.css_t
+++ b/sphinx/static/bottle.css_t
@@ -133,25 +133,36 @@ div.admonition p.last {
 div.admonition {
   border: 1px solid {{ color_border }};
   margin: 1em 2em;
-  padding: 0.5em;
+  padding: 0;
   font-size: 0.9em;
   line-height: 1.3em;
 }
 
 div.admonition p.admonition-title {
-  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: white;
 }
 
-div.admonition p.admonition-title:after {
-  content:":";
+div.admonition p {
+  margin: 0;
+  padding: 0.5em;
 }
 
 div.warning {
   background-color: #fee;
 }
 
+div.warning p.admonition-title {
+  background-color: #ee0000;
+}
+
 div.note {
-  background-color: #ffc;
+  background-color: #e0ffe0;
+}
+
+div.note p.admonition-title {
+  background-color: #008000;
 }
 
 div.highlight {


### PR DESCRIPTION
I think the warnings and notes could be more prominent.  This is an example of how they could look.

Screenshot:
![screenshot of warnings and notes](https://f.cloud.github.com/assets/152008/863469/239635c2-f60a-11e2-9681-0f8f0f78654e.png)
(Warnings screenshot until “Request Data” (incl.); Notes screenshot beginning with “Plugins can be …”)
