### PR TITLE
bug: dev release is not highlighted

### DIFF
--- a/sphinx/templates/sidebar-intro.html
+++ b/sphinx/templates/sidebar-intro.html
@@ -10,7 +10,7 @@
   {% endif %}
 <ul>
   {% for v, name in releases %}
-    {% if v == version %}
+    {% if v in version %}
       <li><b>Bottle {{v}}</b> ({{name}})</li>
     {% else %}
       <li><a href="/docs/{{v}}/">Bottle {{v}}</a> ({{name}})</li>


### PR DESCRIPTION
For 0.12-dev `v == 'dev'` and `version == '0.12-dev'`.  So `v != version`.

Another way of fixing this would be to change the variable `html_context` in [sphinx/conf.py](https://github.com/bottlepy/bottlepy.org/blob/master/sphinx/conf.py#L140).
