### PR TITLE
URL fix for Sphinx documentation attibution

### DIFF
--- a/sphinx/templates/layout.html
+++ b/sphinx/templates/layout.html
@@ -21,7 +21,7 @@
 {% block footer %}
     <div class="footer">
     &copy; <a href="{{ pathto('index') }}#license">Copyright</a> {{ copyright|e }} - <a href="{{ pathto('contact') }}">Contact</a><br />
-    Last updated on {{ last_updated|e }}. Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> {{ sphinx_version|e }}.<br />
+    Last updated on {{ last_updated|e }}. Created using <a href="https://www.sphinx-doc.org">Sphinx</a> {{ sphinx_version|e }}.<br />
     Powered by Bottle {{version|e}}
     </div>
 {% endblock %}


### PR DESCRIPTION
Sphinx is now hosted at a new URL.